### PR TITLE
Fix importing activations

### DIFF
--- a/keras_transformer/transformer.py
+++ b/keras_transformer/transformer.py
@@ -6,8 +6,8 @@ Contains implementation of the Transformer model described in papers
 import math
 from typing import Union, Callable, Optional
 
-from keras.layers import Layer, Add, activations, Dropout
-from keras import initializers
+from keras.layers import Layer, Add, Dropout
+from keras import initializers, activations
 # noinspection PyPep8Naming
 from keras import backend as K
 from keras.utils import get_custom_objects


### PR DESCRIPTION
keras.layers.activations doesn't seem to be in keras 2.3.1 anymore, so imported from keras.activations instead