### PR TITLE
activations moved from keras.layers to keras in keras 2.2.0

### DIFF
--- a/keras_transformer/transformer.py
+++ b/keras_transformer/transformer.py
@@ -6,7 +6,8 @@ Contains implementation of the Transformer model described in papers
 import math
 from typing import Union, Callable, Optional
 
-from keras.layers import Layer, Add, activations, Dropout
+from keras.layers import Layer, Add, Dropout
+from keras import activations
 from keras import initializers
 # noinspection PyPep8Naming
 from keras import backend as K

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     keywords='development',
 
     packages=find_packages(where='.', exclude=['example']),
-    install_requires=['Keras>=2.0.8', 'numpy'],
+    install_requires=['Keras>=2.2.0', 'numpy'],
     tests_require=['pytest'],
     include_package_data=True,
 )


### PR DESCRIPTION
We used Keras-Transformer in [Kaggle University of Liverpool - Ion Switching competition](https://www.kaggle.com/c/liverpool-ion-switching) but we had an issue because `activations` wasn't found in `keras_transformer/transformer.py`

You can see the notebook in https://www.kaggle.com/josecarmona/test-of-transformer-over-data-without-drift

We check `keras_transformer/extras.py` was moved but not in `keras_transformer/transformer.py` so we fix it and increase requirement of Keras version to 2.2.0.